### PR TITLE
refactor: 운세 API 응답 속도 최적화

### DIFF
--- a/app/context_construction/query_rewriter.py
+++ b/app/context_construction/query_rewriter.py
@@ -1,3 +1,5 @@
+# app/context_construction/query_rewriter.py
+
 def build_fortune_prompt(course: str, date: str) -> str:
     return f"""
 You are an AI that only outputs a single JSON object—nothing else.
@@ -6,6 +8,7 @@ Output exactly this JSON structure with values in Korean.
 overall, devLuck each short one‐sentence.
 overall에는 전반적인 하루 운세를 적고, devLuck에는 course별 개발자용 운세 적어줘.
 Output exactly:
+```json
 {{
   "overall": "",
   "devLuck": ""

--- a/app/fast_api/endpoints/fortune_router.py
+++ b/app/fast_api/endpoints/fortune_router.py
@@ -1,29 +1,52 @@
 # app/fast_api/endpoints/fortune_router.py
 
 from fastapi import APIRouter, HTTPException
-from fast_api.schemas.fortune_schema import FortuneRequest
+from fast_api.schemas.fortune_schema import FortuneRequest, FortuneResponse
 from model_inference.inference_runner import run_fortune_model
-import json
-import re
+import json, re
+import time
 
 router = APIRouter()
 
-@router.post("/api/llm/fortune")
+@router.post(
+    "/fortune",                                 # ← prefix는 main.py 에서 한 번만 붙여주므로 여기서는 /fortune
+    response_model=FortuneResponse,             # ← response_model 지정
+    summary="Create Fortune",
+    tags=["Fortune"],
+)
 async def create_fortune(request: FortuneRequest):
+    # 1) 시작 시간 기록
+    start = time.perf_counter()
+
+    # 2) 모델 호출
     model_output = run_fortune_model(request.course, request.date)
 
+    # 3) 종료 시간 기록 & elapsed 계산
+    elapsed = time.perf_counter() - start
+    print(f"⏱️ Endpoint elapsed: {elapsed:.2f} sec")
+
+
+    # (디버그) raw log
     print("🔥 RAW MODEL OUTPUT BEGIN 🔥")
     print(model_output)
     print("🔥 RAW MODEL OUTPUT END 🔥")
 
-    # JSON 블록 추출 & 파싱
-    try:
-        match = re.search(r"\{[\s\S]*?\}", model_output)
-        if not match:
-            raise HTTPException(status_code=500, detail="No JSON found in model output.")
-        parsed = json.loads(match.group())
-    except json.JSONDecodeError:
-        raise HTTPException(status_code=500, detail="Model output is not a valid JSON.")
+    # 2) JSON 블록 추출 & 파싱
+    # 이미 dict 로 파싱되어 있으면 그대로, 아니면 문자열에서 JSON 블록 추출
+    if isinstance(model_output, dict):
+        parsed = model_output
+    else:
+        try:
+            match = re.search(r"\{[\s\S]*?\}", model_output)
+            if not match:
+                raise HTTPException(status_code=500, detail="No JSON found in model output.")
+            parsed = json.loads(match.group())
+        except json.JSONDecodeError:
+            raise HTTPException(status_code=500, detail="Model output is not a valid JSON.")
+ 
 
-
-    return {"message": "generateFortuneSuccess", "data": parsed}
+    # 3) FastAPI 가 응답 스키마 검증까지 알아서 해 줌
+    return {
+        "message": "generateFortuneSuccess",
+        "data": parsed
+    }

--- a/app/fast_api/schemas/fortune_schema.py
+++ b/app/fast_api/schemas/fortune_schema.py
@@ -1,6 +1,14 @@
+# app/fast_api/schemas/fortune_schema.py
+from pydantic import BaseModel
+from typing import Literal, Dict
+
 from pydantic import BaseModel
 
 class FortuneRequest(BaseModel):
     memberId: int
     course: str
     date: str
+
+class FortuneResponse(BaseModel):
+    message: str
+    data: dict

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from fast_api.endpoints.fortune_router import router as fortune_router
 import uvicorn
 
 app = FastAPI()
-app.include_router(fortune_router, tags=["Fortune"])
+app.include_router(fortune_router, prefix="/api/llm", tags=["Fortune"])
 
 if __name__ == "__main__":
-    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/app/model_inference/inference_runner.py
+++ b/app/model_inference/inference_runner.py
@@ -1,8 +1,30 @@
-#inference_runner.py
+# app/model_inference/inference_runner.py
 
+import json
+import re
 from context_construction.query_rewriter import build_fortune_prompt
 from model_inference.loaders.HyperCLOVA_loader import generate_fortune_text
 
-def run_fortune_model(course: str, date: str) -> str:
+def run_fortune_model(course: str, date: str) -> dict:
+    # 1) JSON 전용 프롬프트 생성
     prompt = build_fortune_prompt(course, date)
-    return generate_fortune_text(prompt)
+
+    # 2) 모델에 프롬프트만 전달
+    raw = generate_fortune_text(prompt)
+
+    # 3) { … } 블록 모두 찾고, 마지막 블록만 취함
+    blocks = re.findall(r"\{[\s\S]*?\}", raw)
+    if not blocks:
+        raise RuntimeError(f"모델 출력에 JSON 블록이 없습니다:\n{raw}")
+    last = blocks[-1]
+
+    # 4) JSON 파싱
+    try:
+        return json.loads(last)
+    except json.JSONDecodeError as e:
+        # 디버그용 전체 raw 및 추출 블록 출력
+        raise RuntimeError(
+            f"JSON 파싱 실패: {e}\n"
+            f"추출된 블록:\n{last}\n\n"
+            f"원본 출력:\n{raw}"
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ huggingface-hub
 python-dotenv
 numpy<2
 sentencepiece
+accelerate>=0.20.3
+bitsandbytes>=0.41.0
+llama-cpp-python
+langchain


### PR DESCRIPTION
## ⭐Key Changes

1. LangChain의 `StructuredOutputParser` → **커스텀 JSON 파싱 로직** 도입  
   - `inference_runner.py` 에서 정규표현식으로 마지막 JSON 블록만 추출해 `json.loads` 처리  
   - `JSONOutputParser` 는 사용하지 않고, 직접 `dict` 반환 방식으로 안정성 강화  

2. 프롬프트 & 생성 길이 최적화  
   - `max_new_tokens=300` → **120** 으로 축소  
   - 샘플링 제거 (`do_sample=False`), `eos_token_id` 명시로 조기 종료 유도  

3. 추론 설정 튜닝  
   - CPU: FP32  
   - CUDA GPU: FP16 혼합정밀도 (`torch_dtype=torch.float16`, `device_map="auto"`)  
   - macOS MPS (개발 환경): FP32 (안정성 우선)  

4. FastAPI 라우터 정리  
   - `main.py` 에서 `/api/llm` prefix 일원화  
   - `fortune_router.py` 에 `response_model` 추가, 중복 로직 제거  

5. 성능 측정 & 로깅  
   - `test.py` 와 엔드포인트에 `time.perf_counter()` 로 추론 소요 시간 기록  

---

## ⏱️예상 추론 속도

| 환경                    | 실제 측정 (FP32) | 기대 (FP16)           |
| --------------------- | ------------- | ------------------- |
| CPU (FP32, 로컬)        | 22초            | —                   |
| GPU FP32 (예: T4)       | 3.5–4.5초       | —                   |
| GPU FP16 (예: T4)       | 2.5–3.5초       | —                   |
| GPU FP16 (GCP L4)      | 1.5–2.5초       | **≤2초**              |

*FP16 적용 시 2초 이하 추론 예상*

---

## 🖐️To reviewers

1. CUDA/MPS/CPU 분기 로직이 의도한 대로 동작하는지 검증해 주세요.  
2. FP16 혼합정밀도 적용 후 품질 저하 여부도 함께 테스트 부탁드립니다.

<br />

## 📌Issues

- Closes #4 (JSON 파싱 안정화)  
- Closes #5 (속도 튜닝 및 프롬프트 리팩토링)  
