### PR TITLE
fix: course 필드 누락시 문제 해결

### DIFF
--- a/app/fast_api/schemas/fortune_schema.py
+++ b/app/fast_api/schemas/fortune_schema.py
@@ -3,12 +3,13 @@
 
 from pydantic import BaseModel
 from typing import Literal, Dict
+from typing import Optional
 
 from pydantic import BaseModel
 
 class FortuneRequest(BaseModel):
     name: str
-    course: str
+    course: Optional[str] = None
     date: str
 
 class FortuneResponse(BaseModel):

--- a/app/model_inference/fortune_inference_runner.py
+++ b/app/model_inference/fortune_inference_runner.py
@@ -31,6 +31,12 @@ def run_fortune_model(name: str, course: str, date: str) -> dict:
     사용자 입력(name, course, date)을 받아 운세 모델을 호출하고,
     결과를 JSON으로 파싱해 반환합니다. 실패 시 fallback 메시지를 사용합니다.
     """
+
+    # Null-safe 처리
+    if course is None or str(course).lower() == "null":
+        course = "외부인"
+
+    
     for attempt in range(1, MAX_RETRY + 1):
         # 프롬프트에 난수 기반 노이즈 추가 (모델 응답 다양성 확보)
         noise = f"<!-- retry_seed={random.randint(0,9999)} -->"


### PR DESCRIPTION
## ⭐Key Changes

1. `fortune_schema.py`에서 `course`를 `Optional[str] = None` 으로 변경하여 null 또는 누락된 입력 허용
2. `fortune_inference_runner.py`에서 `course`가 `None` 또는 "null"일 경우 `"외부인"`으로 치환 처리
3. Postman을 통한 다양한 입력 케이스 테스트 완료 (null, 생략, 정상 입력 모두 정상 작동 확인)

<br />

## 🖐️To reviewers

1. 혹시 다른 스키마에도 비슷한 필수 필드가 있을 경우 동일한 패턴으로 처리할 수 있습니다.


<br />

## 📌 issue

- close #63 