### PR TITLE
위, 아래로 뱃지에 선이 발생하여 삭제하였습니다.

### DIFF
--- a/.github/workflows/cicd-badge-dev.yml
+++ b/.github/workflows/cicd-badge-dev.yml
@@ -12,6 +12,7 @@ on:
       - dev
       - feat/100-badge-DeploymentEnvironment
       - feat/125-badge-regularInstance
+      - feat/177-badge-dilated
 
 jobs:
   build-push:

--- a/app/context_construction/prompts/badge_prompt.py
+++ b/app/context_construction/prompts/badge_prompt.py
@@ -105,7 +105,7 @@ class BadgePrompt:
         w, h = pil_img.size
 
         # 위 아래 2픽셀씩 자르기 (좌측, 위, 우측, 아래)
-        cropped_img = pil_img.crop((10, 10, w - 10, h - 10))
+        cropped_img = pil_img.crop((30, 30, w - 30, h - 30))
         w, h = cropped_img.size
 
         logger.info(f"img_size: {w}, {h}")

--- a/app/context_construction/prompts/badge_prompt.py
+++ b/app/context_construction/prompts/badge_prompt.py
@@ -105,7 +105,7 @@ class BadgePrompt:
         w, h = pil_img.size
 
         # 위 아래 2픽셀씩 자르기 (좌측, 위, 우측, 아래)
-        cropped_img = pil_img.crop((30, 30, w - 30, h - 30))
+        cropped_img = pil_img.crop((15, 15, w - 15, h - 15))
         w, h = cropped_img.size
 
         logger.info(f"img_size: {w}, {h}")
@@ -118,7 +118,7 @@ class BadgePrompt:
         new_h = int(h * scale)
 
         # 이미지 리사이즈 (LANCZOS는 고품질)
-        resized_img = pil_img.resize((new_w, new_h), Image.LANCZOS)
+        resized_img = cropped_img.resize((new_w, new_h), Image.LANCZOS)
 
         # 흰색 배경 128x128 생성
         background = Image.new("RGB", (128, 128), (255, 255, 255))

--- a/app/context_construction/prompts/badge_prompt.py
+++ b/app/context_construction/prompts/badge_prompt.py
@@ -44,7 +44,7 @@ class BadgePrompt:
 
         draw.ellipse([
             center[0] - outer_radius, center[1] - outer_radius,
-            center[0] - outer_radius, center[1] - outer_radius
+            center[0] + outer_radius, center[1] + outer_radius
         ], outline=0, width=6)
 
         # 5. Canny 엣지 적용 및 저장
@@ -105,8 +105,8 @@ class BadgePrompt:
         w, h = pil_img.size
 
         # 위 아래 2픽셀씩 자르기 (좌측, 위, 우측, 아래)
-        cropped_img = pil_img.crop((5, 5, w - 5, h - 5))
-        w, h = cropped_img.size
+        # cropped_img = pil_img.crop((5, 5, w - 5, h - 5))
+        # w, h = cropped_img.size
 
         logger.info(f"img_size: {w}, {h}")
         # if w < 50 or h < 50:
@@ -118,7 +118,7 @@ class BadgePrompt:
         new_h = int(h * scale)
 
         # 이미지 리사이즈 (LANCZOS는 고품질)
-        resized_img = cropped_img.resize((new_w, new_h), Image.LANCZOS)
+        resized_img = pil_img.resize((new_w, new_h), Image.LANCZOS)
 
         # 흰색 배경 128x128 생성
         background = Image.new("RGB", (128, 128), (255, 255, 255))
@@ -149,6 +149,7 @@ class BadgePrompt:
         # gc.collect()
 
         # return background
+
     async def img_preprocessing(self, Pil_image):
         small_img = Pil_image.resize((64, 64))  # 주요 색 추출을 위해 이미지 사이즈 조정.
 

--- a/app/context_construction/prompts/badge_prompt.py
+++ b/app/context_construction/prompts/badge_prompt.py
@@ -105,7 +105,7 @@ class BadgePrompt:
         w, h = pil_img.size
 
         # 위 아래 2픽셀씩 자르기 (좌측, 위, 우측, 아래)
-        cropped_img = pil_img.crop((15, 15, w - 15, h - 15))
+        cropped_img = pil_img.crop((5, 5, w - 5, h - 5))
         w, h = cropped_img.size
 
         logger.info(f"img_size: {w}, {h}")

--- a/app/context_construction/prompts/badge_prompt.py
+++ b/app/context_construction/prompts/badge_prompt.py
@@ -101,7 +101,13 @@ class BadgePrompt:
         # new_h = int(h * scale)
 
         # resized_logo = cv2.resize(np_img, (new_w, new_h), interpolation=cv2.INTER_CUBIC)
+
         w, h = pil_img.size
+
+        # 위 아래 2픽셀씩 자르기 (좌측, 위, 우측, 아래)
+        cropped_img = pil_img.crop((0, 2, w, h - 2))
+        w, h = cropped_img.size
+
         logger.info(f"img_size: {w}, {h}")
         # if w < 50 or h < 50:
         #     return None
@@ -185,7 +191,7 @@ class BadgePrompt:
         logger.info(f"3-7-9) 업스케일링 완료")
         resized = cv2.resize(upscaled, (512, 512), interpolation=cv2.INTER_LANCZOS4)
 
-        canny_logo = cv2.Canny(resized, 50, 200)[8:-8, 8:-8]
+        canny_logo = cv2.Canny(resized, 50, 200)
 
         #선을 두껍게 변경.s
         kernel = np.ones((3, 3), np.uint8)  # 커널 크기 (선 굵기 조절)

--- a/app/context_construction/prompts/badge_prompt.py
+++ b/app/context_construction/prompts/badge_prompt.py
@@ -105,7 +105,7 @@ class BadgePrompt:
         w, h = pil_img.size
 
         # 위 아래 2픽셀씩 자르기 (좌측, 위, 우측, 아래)
-        cropped_img = pil_img.crop((0, 2, w, h - 2))
+        cropped_img = pil_img.crop((10, 10, w - 10, h - 10))
         w, h = cropped_img.size
 
         logger.info(f"img_size: {w}, {h}")

--- a/app/context_construction/prompts/badge_prompt.py
+++ b/app/context_construction/prompts/badge_prompt.py
@@ -91,7 +91,7 @@ class BadgePrompt:
 
         return output_img.astype(np.uint8)
     
-    async def remove_alpha_to_white_bg(self, PIL_img: Image.Image) -> Image.Image:
+    async def remove_alpha_to_white_bg(self, PIL_img: Image.Image, new_w, new_h) -> Image.Image:
         """
         이미지에 알파 채널이 있으면 흰 배경에 붙여서 RGB 이미지로 변환합니다.
         알파 채널이 없으면 그대로 반환합니다.
@@ -102,9 +102,12 @@ class BadgePrompt:
         # 흰 배경 생성
         bg = Image.new("RGBA", (128,128), (255, 255, 255, 255))
 
+        x_offset = (128 - new_w) // 2
+        y_offset = (128 - new_h) // 2
+
         # 알파 마스크로 병합
         alpha = PIL_img.split()[3]
-        bg.paste(PIL_img, mask=alpha)
+        bg.paste(PIL_img, (x_offset, y_offset), mask=alpha)
 
         del PIL_img, alpha
         gc.collect()
@@ -140,10 +143,12 @@ class BadgePrompt:
 
         # 이미지 리사이즈 (LANCZOS는 고품질)
         resized_img = pil_img.resize((new_w, new_h), Image.LANCZOS)
-        # plt.imshow(resized_img, cmap='gray') #삭제
-        # plt.show()
+        plt.imshow(resized_img, cmap='gray') #삭제
+        plt.show()
         
-        background = await self.remove_alpha_to_white_bg(resized_img)
+        background = await self.remove_alpha_to_white_bg(resized_img, new_w, new_h)
+        plt.imshow(background)
+        plt.show()
 
         # # 흰색 배경 128x128 생성
         # background = Image.new("RGB", (128, 128), (255, 255, 255, 255))

--- a/app/context_construction/prompts/badge_prompt.py
+++ b/app/context_construction/prompts/badge_prompt.py
@@ -143,12 +143,12 @@ class BadgePrompt:
 
         # 이미지 리사이즈 (LANCZOS는 고품질)
         resized_img = pil_img.resize((new_w, new_h), Image.LANCZOS)
-        plt.imshow(resized_img, cmap='gray') #삭제
-        plt.show()
+        # plt.imshow(resized_img, cmap='gray') #삭제
+        # plt.show()
         
         background = await self.remove_alpha_to_white_bg(resized_img, new_w, new_h)
-        plt.imshow(background)
-        plt.show()
+        # plt.imshow(background)
+        # plt.show()
 
         # # 흰색 배경 128x128 생성
         # background = Image.new("RGB", (128, 128), (255, 255, 255, 255))


### PR DESCRIPTION
## ⭐Key Changes

1. 미야옹, Looper, 커리어비, 모아 등 뱃지내 로고주변에 아래와 같이 선이 생겨, 원인 파악및 문제 해결하였습니다.

문제 발생 | 원인 파악 | 문제 해결
-- | -- | --
<img width="435" alt="image" src="https://github.com/user-attachments/assets/eb01483f-b279-4170-8217-eb1a1402e01c" /> | <img width="252" alt="image" src="https://github.com/user-attachments/assets/420cf23d-9ad4-4017-b9f5-f2ebcbb0ae09" /> | <img width="273" alt="image" src="https://github.com/user-attachments/assets/23b60345-298e-44f6-81cb-bb9d520f2d8f" />
위 이미지와 같이 팀 로고 위, 아래로 두꺼운 선이 생겼음. | 정 사각형의 이미지를 만들기위해 로고와 흰 배경을 병합하는 과정에서 배경색이 달라, 위, 아래로 경계선이 생긴 것이 원인으로 파악됨 | 해당 이미지를 우선 canny이미지(AI 입력이미지)로 변환하고 해당 라인을 지우는 방법으로 해결함. 


## 🖐️To reviewers

1. 입력데이터를 전처리 과정에서 고도화 한 작업입니다.
2. 전처리 데이터가 더 깔끔해져, 결과도 이에 따라 고도화 되었습니다.
