### PR TITLE
fix: generate_answer에서 불필요한 정규식 제거하고 raw_output 그대로 반환

### DIFF
--- a/app/services/team_chat_service.py
+++ b/app/services/team_chat_service.py
@@ -49,9 +49,12 @@ class TeamChatService:
         raw_output = self.vllm_client.generate(prompt)
         print("🧾 My model full response (for debug):", repr(raw_output.replace('\n', '\\n')))
 
-        match = re.search(r"[가-힣][^a-zA-Z0-9]{0,10}", raw_output)
-        if match:
-            cleaned = raw_output[match.start():]
-        else:
-            cleaned = raw_output
-        return cleaned
+        # 그대로 리턴
+        return raw_output
+
+        # match = re.search(r"[가-힣][^a-zA-Z0-9]{0,10}", raw_output)
+        # if match:
+        #     cleaned = raw_output[match.start():]
+        # else:
+        #     cleaned = raw_output
+        # return cleaned


### PR DESCRIPTION
## ⭐Key Changes

LLM 응답의 앞부분이 잘리는 현상이 있었습니다.

LLM 응답에서 실제 사용자에게 전달해야 하는 부분에서 불필요한 정규식 제거하여 해결하였습니다. 


## 📌 issue

- close #219 